### PR TITLE
Refactor: Simplify CORS origin configuration using site config origin

### DIFF
--- a/src/lib/server/cors.ts
+++ b/src/lib/server/cors.ts
@@ -1,8 +1,7 @@
-import { dev } from '$app/environment';
 import cors from 'cors';
 import { siteConfig } from '$lib/metadata';
 
-const allowedOrigins = dev ? 'http://localhost:5173' : siteConfig.url.toString();
+const allowedOrigins = siteConfig.url.origin;
 
 const corsMiddleware = cors({
 	origin: (origin, callback) => {


### PR DESCRIPTION
This pull request includes a change to the `src/lib/server/cors.ts` file to update the configuration for allowed origins in the CORS middleware. The most important change is the removal of the development environment check for setting the allowed origins.

Configuration update:

* [`src/lib/server/cors.ts`](diffhunk://#diff-52698d5cb5f464548efd573f5c25aad1aa1763de80e5f4a36976d0f775d2390aL1-R4): Removed the check for the development environment and set `allowedOrigins` to use `siteConfig.url.origin` directly.